### PR TITLE
added support for calling then on return of async function

### DIFF
--- a/tests-unit/input/async-catch-clean-2/spec.json
+++ b/tests-unit/input/async-catch-clean-2/spec.json
@@ -1,0 +1,24 @@
+{
+    "main": "test.js",
+    "tracking": "Boolean",
+    "sources": [
+        {
+            "type": "variable",
+            "name": "a",
+            "location": {
+                "fileName": "test.js"
+            }
+        }
+    ],
+    "sinks": [
+        {
+            "type": "variable",
+            "name": "z",
+            "location": {
+                "fileName": "test.js"
+            }
+        }
+    ],
+    "expectedFlows": [
+    ]
+}

--- a/tests-unit/input/async-catch-clean-2/test.js
+++ b/tests-unit/input/async-catch-clean-2/test.js
@@ -1,0 +1,9 @@
+const a = 3;
+
+async function identity(x) {
+    throw x;
+}
+
+identity(a).then((v) => {
+    const z = v;
+})

--- a/tests-unit/input/async-catch-clean/spec.json
+++ b/tests-unit/input/async-catch-clean/spec.json
@@ -1,0 +1,24 @@
+{
+    "main": "test.js",
+    "tracking": "Boolean",
+    "sources": [
+        {
+            "type": "variable",
+            "name": "a",
+            "location": {
+                "fileName": "test.js"
+            }
+        }
+    ],
+    "sinks": [
+        {
+            "type": "variable",
+            "name": "z",
+            "location": {
+                "fileName": "test.js"
+            }
+        }
+    ],
+    "expectedFlows": [
+    ]
+}

--- a/tests-unit/input/async-catch-clean/test.js
+++ b/tests-unit/input/async-catch-clean/test.js
@@ -1,0 +1,9 @@
+const a = 3;
+
+async function identity(x) {
+    return x;
+}
+
+identity(a).catch((v) => {
+    const z = v;
+})

--- a/tests-unit/input/async-catch-tainted/spec.json
+++ b/tests-unit/input/async-catch-tainted/spec.json
@@ -1,0 +1,31 @@
+{
+    "main": "test.js",
+    "tracking": "Boolean",
+    "sources": [
+        {
+            "type": "variable",
+            "name": "a",
+            "location": {
+                "fileName": "test.js"
+            }
+        }
+    ],
+    "sinks": [
+        {
+            "type": "variable",
+            "name": "z",
+            "location": {
+                "fileName": "test.js"
+            }
+        }
+    ],
+    "expectedFlows": [
+        {
+            "type": "variable",
+            "name": "z",
+            "location": {
+                "fileName": "test.js"
+            }
+        }
+    ]
+}

--- a/tests-unit/input/async-catch-tainted/test.js
+++ b/tests-unit/input/async-catch-tainted/test.js
@@ -1,0 +1,9 @@
+const a = 3;
+
+async function identity(x) {
+    throw x;
+}
+
+identity(a).catch((v) => {
+    const z = v;
+})

--- a/ts/src/abstractMachine/JSMachine.ts
+++ b/ts/src/abstractMachine/JSMachine.ts
@@ -184,7 +184,7 @@ export default abstract class JSMachine<V, F> implements AbstractMachine {
     }
 
     public installAdvice(adviceStack: Array<Function>, f: Function): void {
-        adviceStack[adviceStack.length - 1] = f;
+        adviceStack.push(f);
     }
 
     public reportFlow(flow: F) {
@@ -558,9 +558,17 @@ export default abstract class JSMachine<V, F> implements AbstractMachine {
 
     public binary = this.binaryOp.wrapper;
 
+    public initVarAdvice: {(name : any, description: StaticDescription): void}[] = [];
     public initVarOp: Operation<[VariableDescription, StaticDescription], void> =
         this.adviceWrap(
             ([s, description]) => {
+                // Deal with advice, if there is any.
+                let advice = this.initVarAdvice.pop();
+                if (advice != undefined) {
+                    advice(s, description);
+                    return;
+                }
+
                 let v = this.join(this.taintTree.get(this.ROOTID)[
                 this.taintTree.get(this.ROOTID).length - 1], this.produceMark(description));
 
@@ -681,10 +689,11 @@ export default abstract class JSMachine<V, F> implements AbstractMachine {
         });
     public asyncFunctionEnter = this.asyncFunctionEnterOp.wrapper;
 
+    // this.state.asyncFunctionExit([iid, this.getAsyncPromiseId(result), result, exceptionVal, {type: "asyncFunctionExit", location: parseIID(iid)}])
     public asyncFunctionExitOp: Operation<[number, DynamicDescription, any, ExceptionVal, StaticDescription], void> =
         this.adviceWrap(([iid, promiseId, result, exceptionVal, description]) => {
             let v = this.returnValue;
-            this.asyncPromiseMap.set(promiseId, {resolve: v , reject: v})
+            this.asyncPromiseMap.set(promiseId, {resolve: v , reject: exceptionVal.exception})
 
             if (promiseDebug || debug) console.log("asyncExit: " + this.taintTree.get(0))
         });

--- a/ts/src/analysis/analysis.ts
+++ b/ts/src/analysis/analysis.ts
@@ -347,7 +347,7 @@ export default class Analysis implements Analyzer {
     }
 
     public asyncFunctionExit: NPCallbacks.asyncFunctionExit = (iid: number, result: any, exceptionVal: ExceptionVal) => {
-        this.state.asyncFunctionExit([iid, this.getAsyncPromiseId(result),  result, exceptionVal, {type: "asyncFunctionExit", location: parseIID(iid)}])
+        this.state.asyncFunctionExit([iid, this.getAsyncPromiseId(result), result, exceptionVal, {type: "asyncFunctionExit", location: parseIID(iid)}])
     }
 
     public awaitPre: NPCallbacks.awaitPre = (iid: number, promiseOrAwaitedVal: any) => {

--- a/ts/tests/runner.test.js
+++ b/ts/tests/runner.test.js
@@ -94,15 +94,17 @@ test('for-in-clean', (done) => runTest('for-in-clean', done));
 test('for-in-tainted', (done) => runTest('for-in-tainted', done));
 test('init-destructure-obj-clean', (done) => runTest('init-destructure-obj-clean', done));
 
-// TODO: async-await/promises not yet supported
-// test('promise-await-clean', (done) => runTest('promise-await-clean', done));
-// test('promise-await-tainted', (done) => runTest('promise-await-tainted',
-// done));
-// test('promise-then-clean', (done) => runTest('promise-then-clean', done));
-// test('promise-then-tainted', (done) => runTest('promise-then-tainted',
-// done));
-// test('async-await-tainted', (done) => runTest('async-await-tainted', done));
-// test('async-then-tainted', (done) => runTest('async-then-tainted', done));
+test('promise-await-clean', (done) => runTest('promise-await-clean', done));
+test('promise-await-tainted', (done) => runTest('promise-await-tainted',
+done));
+test('promise-then-clean', (done) => runTest('promise-then-clean', done));
+test('promise-then-tainted', (done) => runTest('promise-then-tainted',
+done));
+test('async-await-tainted', (done) => runTest('async-await-tainted', done));
+test('async-then-tainted', (done) => runTest('async-then-tainted', done));
+test('async-catch-tainted', (done) => runTest('async-catch-tainted', done));
+test('async-catch-clean', (done) => runTest('async-catch-clean', done));
+test('async-catch-clean-2', (done) => runTest('async-catch-clean-2', done));
 test('init-destructure-obj-tainted', (done) => runTest('init-destructure-obj-tainted', done));
 
 // New tests


### PR DESCRIPTION
This PR adds support for calling then and catch on promises returned by async functions. This PR also contains a few unit tests to ensure correct taint tracking on relevant code, and additionally uncomments preexisting async/await and promise tests.